### PR TITLE
feat: Store embeddings with EquiformerV2

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -11,7 +11,7 @@ PDD:
 # SIMILARITY
 
 eqv2:
-  threshold: 0.001
+  threshold: 0.999
   trained: True
   cpu: False
   load_from_hf: True

--- a/configs/disordered_structures.yaml
+++ b/configs/disordered_structures.yaml
@@ -11,7 +11,7 @@ PDD:
 # SIMILARITY
 
 eqv2:
-  threshold: 0.001
+  threshold: 0.999
   trained: True
   cpu: False
   load_from_hf: True

--- a/src/material_hasher/similarity/eqv2.py
+++ b/src/material_hasher/similarity/eqv2.py
@@ -249,43 +249,6 @@ class EquiformerV2Similarity(SimilarityMatcherBase):
 
         return score >= threshold
 
-    def get_pairwise_similarity_scores_from_embeddings(
-        self,
-        all_embeddings: list[np.ndarray],
-    ) -> np.ndarray:
-        """Returns a matrix of similarity scores between structures
-        by taking as input a list of their respective embeddings.
-
-        Returns a matrix $M$ where $M_{ij}$ is the similarity score between
-        structure $i$ and structure $j$.
-
-        Parameters
-        ----------
-        all_embeddings : list[np.ndarray]
-            List of embeddings of structures to compare.
-
-        Returns
-        -------
-        np.ndarray
-            Matrix of similarity scores between structures.
-        """
-
-        n = len(all_embeddings)
-        scores = np.zeros((n, n))
-
-        # Fill triu + diag
-        for i, embeddings1 in enumerate(all_embeddings):
-            for j, embeddings2 in enumerate(all_embeddings):
-                if i <= j:
-                    scores[i, j] = self.get_similarity_embeddings(
-                        embeddings1, embeddings2
-                    )
-
-        # Fill tril
-        scores = scores + scores.T - np.diag(np.diag(scores))
-
-        return scores
-
     def get_pairwise_equivalence(
         self, structures: list[Structure], threshold: Optional[float] = None
     ) -> np.ndarray:

--- a/src/material_hasher/similarity/eqv2.py
+++ b/src/material_hasher/similarity/eqv2.py
@@ -250,4 +250,11 @@ class EquiformerV2Similarity(SimilarityMatcherBase):
         if threshold is None:
             threshold = self.threshold
 
-        return self.get_pairwise_similarity_scores(structures) >= threshold
+        all_embeddings = np.array(
+            [self.get_structure_embeddings(s) for s in structures]
+        )
+
+        return (
+            self.get_pairwise_similarity_scores_from_embeddings(all_embeddings)
+            >= threshold
+        )

--- a/src/material_hasher/similarity/eqv2.py
+++ b/src/material_hasher/similarity/eqv2.py
@@ -49,7 +49,7 @@ class EquiformerV2Similarity(SimilarityMatcherBase):
         self,
         trained: bool = True,
         cpu: bool = False,
-        threshold: float = 0.01,
+        threshold: float = 0.999,
         n_relaxation_steps: int = 0,
         model_path: Optional[Union[str, Path]] = None,
         load_from_hf: bool = True,


### PR DESCRIPTION
Before, when comparing a list of structures to each other, the implementation would recompute the vector for every structure every time a comparison was made. This scaled quadratically in the number of structures.

This PR stores the vectors of the entire list before computing the similarity.

It also addresses a bug where there was a confusion between similarity threshold / distance threshold rendering the benchmarks of EquiformerV2 invalid.