### PR TITLE
feat: Default BAWL to moyo symmetry label

### DIFF
--- a/src/material_hasher/hasher/bawl.py
+++ b/src/material_hasher/hasher/bawl.py
@@ -5,7 +5,11 @@ from pymatgen.core import Structure
 from material_hasher.hasher.base import HasherBase
 from material_hasher.hasher.utils.graph import get_weisfeiler_lehman_hash
 from material_hasher.hasher.utils.graph_structure import get_structure_graph
-from material_hasher.hasher.utils.symmetry import AFLOWSymmetry, SPGLibSymmetry
+from material_hasher.hasher.utils.symmetry import (
+    AFLOWSymmetry,
+    MoyoSymmetry,
+    SPGLibSymmetry,
+)
 
 
 class BAWLHasher(HasherBase):
@@ -25,8 +29,9 @@ class BAWLHasher(HasherBase):
     include_composition (bool, optional): Whether to
         include composition in the hash. Defaults to False.
     symmetry_labeling (str, optional): Method for deciding symmetry
-        label. Only AFLOW or SPGLib implemented. AFLOW requires
-        AFLOW python packages. Defaults to "SPGLib".
+        label. Only AFLOW, SPGLib, or moyo implemented. AFLOW requires
+        AFLOW python packages. SPGLib requires SPGLib python packages.
+        moyo requires moyo python packages. Defaults to "moyo".
     shorten_hash (bool, optional): Whether to shorten the hash.
         The shortened hash does not include the symmetry label.
         Defaults to False.
@@ -46,7 +51,7 @@ class BAWLHasher(HasherBase):
         bonding_algorithm: NearNeighbors = EconNN,
         bonding_kwargs: dict = {"tol": 0.2, "cutoff": 10, "use_fictive_radius": True},
         include_composition: bool = True,
-        symmetry_labeling: str = "SPGLib",
+        symmetry_labeling: str = "moyo",
         shorten_hash: bool = False,
     ):
         self.graphing_algorithm = graphing_algorithm
@@ -56,12 +61,17 @@ class BAWLHasher(HasherBase):
         self.symmetry_labeling = symmetry_labeling
         self.shorten_hash = shorten_hash
 
-    def get_bawl_materials_data(self, structure: Structure) -> dict:
+    def get_bawl_materials_data(
+        self, structure: Structure, symmetry_label: int | str | None = None
+    ) -> dict:
         """Gets various hash components for given Pymatgen structure.
 
         Parameters
         ----------
         structure (Structure): pymatgen structure object
+        symmetry_label (int | str | None): symmetry label if already computed.
+            Otherwise, the symmetry label will be computed using the class
+            symmetry_labeling attribute.
 
         Raises
         ------
@@ -87,10 +97,14 @@ class BAWLHasher(HasherBase):
                 "Graphing algorithm {} not implemented".format(self.graphing_algorithm)
             )
         if not self.shorten_hash:
-            if self.symmetry_labeling == "AFLOW":
+            if symmetry_label is not None:
+                data["symmetry_label"] = symmetry_label
+            elif self.symmetry_labeling == "AFLOW":
                 data["symmetry_label"] = AFLOWSymmetry().get_symmetry_label(structure)
             elif self.symmetry_labeling == "SPGLib":
                 data["symmetry_label"] = SPGLibSymmetry().get_symmetry_label(structure)
+            elif self.symmetry_labeling == "moyo":
+                data["symmetry_label"] = MoyoSymmetry().get_symmetry_label(structure)
             else:
                 raise ValueError(
                     "Symmetry algorithm {} not implemented".format(

--- a/src/material_hasher/hasher/bawl.py
+++ b/src/material_hasher/hasher/bawl.py
@@ -97,20 +97,17 @@ class BAWLHasher(HasherBase):
                 "Graphing algorithm {} not implemented".format(self.graphing_algorithm)
             )
         if not self.shorten_hash:
-            if symmetry_label is not None:
-                data["symmetry_label"] = symmetry_label
-            elif self.symmetry_labeling == "AFLOW":
-                data["symmetry_label"] = AFLOWSymmetry().get_symmetry_label(structure)
-            elif self.symmetry_labeling == "SPGLib":
-                data["symmetry_label"] = SPGLibSymmetry().get_symmetry_label(structure)
-            elif self.symmetry_labeling == "moyo":
-                data["symmetry_label"] = MoyoSymmetry().get_symmetry_label(structure)
-            else:
-                raise ValueError(
-                    "Symmetry algorithm {} not implemented".format(
-                        self.symmetry_labeling
-                    )
-                )
+            match (self.symmetry_labeling, symmetry_label):  
+                case (_, label) if label is not None:  
+                    data["symmetry_label"] = label  
+                case ("AFLOW", _):  
+                    data["symmetry_label"] = AFLOWSymmetry().get_symmetry_label(structure)  
+                case ("SPGLib", _):  
+                    data["symmetry_label"] = SPGLibSymmetry().get_symmetry_label(structure)  
+                case ("moyo", _):  
+                    data["symmetry_label"] = MoyoSymmetry().get_symmetry_label(structure)  
+                case (unknown, _):  
+                    raise ValueError(f"Symmetry algorithm {unknown} not implemented")  
         if self.include_composition:
             data["composition"] = structure.composition.formula.replace(" ", "")
         return data
@@ -129,7 +126,7 @@ class BAWLHasher(HasherBase):
             Hash of the structure.
         """
         data = self.get_bawl_materials_data(structure)
-        return "_".join([str(v) for k, v in data.items()])
+        return "_".join([str(v) if v is not None else "" for k, v in data.items()])
 
 
 class ShortBAWLHasher(BAWLHasher):

--- a/src/material_hasher/hasher/utils/symmetry.py
+++ b/src/material_hasher/hasher/utils/symmetry.py
@@ -1,9 +1,54 @@
 # Copyright 2025 Entalpic
 from shutil import which
 
+import moyopy
 from monty.tempfile import ScratchDir
+from moyopy.interface import MoyoAdapter
 from pymatgen.analysis.structure_analyzer import SpacegroupAnalyzer
 from pymatgen.core import Structure
+
+
+class MoyoSymmetry:
+    """
+    Moyo symmetry using Moyo library
+
+    Parameters
+    ----------
+    symprec : float, optional
+        Symmetry precision tollerance. Defaults to 1e-4.
+    angle_tolerance : float, optional
+        Angle tolerance. Defaults to None.
+    setting : str, optional
+        Setting. Defaults to None.
+    """
+
+    def __init__(
+        self, symprec: float = 1e-4, angle_tolerance: float = None, setting: str = None
+    ):
+        self.symprec = symprec
+        self.angle_tolerance = angle_tolerance
+        self.setting = setting
+
+    def get_symmetry_label(self, structure: Structure) -> int:
+        """Get symmetry space group number from structure
+
+        Parameters
+        ----------
+        structure : Structure
+            Input structure
+
+        Returns
+        -------
+        int: space group number
+        """
+        cell = MoyoAdapter.from_structure(structure)
+        dataset = moyopy.MoyoDataset(
+            cell=cell,
+            symprec=self.symprec,
+            angle_tolerance=self.angle_tolerance,
+            setting=self.setting,
+        )
+        return dataset.number
 
 
 class SPGLibSymmetry:
@@ -48,7 +93,6 @@ class AFLOWSymmetry:
         Raises:
             RuntimeError: If AFLOW is not found
         """
-        from aflow_xtal_finder import XtalFinder
 
         self.aflow_executable = aflow_executable or which("aflow")
 
@@ -70,6 +114,10 @@ class AFLOWSymmetry:
         Returns:
             str: AFLOW label
         """
+
+        # fmt: off
+        from aflow_xtal_finder import XtalFinder
+        # fmt: on
 
         xtf = XtalFinder(self.aflow_executable)
         with ScratchDir("."):


### PR DESCRIPTION
Since `moyo` seems to be more reliable than `spglib` and is the default that we are going to use for the LeMat-Bulk symmetry label, let's switch to it for the BAWL hasher as well.