### PR TITLE
Update BAWL to use reduced composition and allow for primitive structure reduction.

### DIFF
--- a/src/material_hasher/hasher/utils/graph_structure.py
+++ b/src/material_hasher/hasher/utils/graph_structure.py
@@ -3,12 +3,16 @@ from pymatgen.analysis.graphs import StructureGraph
 from pymatgen.analysis.local_env import EconNN, NearNeighbors
 from pymatgen.core import Structure
 from networkx import Graph
+from moyopy import MoyoDataset
+from moyopy.interface import MoyoAdapter
+import warnings
 
 
 def get_structure_graph(
     structure: Structure,
     bonding_kwargs: dict = {},
     bonding_algorithm: NearNeighbors = EconNN,
+    primitive_reduction: bool = False,
 ) -> Graph:
     """Method to build networkx graph object based on
     bonding algorithm from Pymatgen Structure
@@ -23,11 +27,18 @@ def get_structure_graph(
     Returns:
         Graph: networkx Graph object
     """
+    assess_structure = (
+        MoyoAdapter.get_structure(
+            MoyoDataset(MoyoAdapter.from_structure(structure)).prim_std_cell
+        )
+        if primitive_reduction
+        else structure.copy()
+    )
     structure_graph = StructureGraph.with_local_env_strategy(
-        structure=structure,
+        structure=assess_structure,
         strategy=bonding_algorithm(**bonding_kwargs),
     )
-    for n, site in zip(range(len(structure)), structure):
+    for n, site in zip(range(len(assess_structure)), assess_structure):
         structure_graph.graph.nodes[n]["specie"] = site.specie.name
     for edge in structure_graph.graph.edges:
         structure_graph.graph.edges[edge]["voltage"] = structure_graph.graph.edges[


### PR DESCRIPTION
**Problem**: currently for some structures, the conventional cell returns a different hash than the primitive cell. For supercell, the full composition is used, so also a different hash is returned. (pointed out by @bkmi in #20 )

**Solution**: Ideally a supercell, or a conventional vs. primitive cell of a material should return the same hash. Propose update to BAWL to account for both reduced composition (which we initially did in LeMat-Bulk) and to account for transformation to primitive cell using Moyopy.

**To do**: would welcome benchmarks that transform materials to either primitive or conventional to test whether various hash function well against that. Or move to switch all hash to consider only the primitive transformation via Moyo?