### PR TITLE
chore: Revert default symmetry labeler to spglib

### DIFF
--- a/src/material_hasher/hasher/bawl.py
+++ b/src/material_hasher/hasher/bawl.py
@@ -51,7 +51,7 @@ class BAWLHasher(HasherBase):
         bonding_algorithm: NearNeighbors = EconNN,
         bonding_kwargs: dict = {"tol": 0.2, "cutoff": 10, "use_fictive_radius": True},
         include_composition: bool = True,
-        symmetry_labeling: str = "moyo",
+        symmetry_labeling: str = "SPGLib",
         shorten_hash: bool = False,
     ):
         self.graphing_algorithm = graphing_algorithm
@@ -97,17 +97,23 @@ class BAWLHasher(HasherBase):
                 "Graphing algorithm {} not implemented".format(self.graphing_algorithm)
             )
         if not self.shorten_hash:
-            match (self.symmetry_labeling, symmetry_label):  
-                case (_, label) if label is not None:  
-                    data["symmetry_label"] = label  
-                case ("AFLOW", _):  
-                    data["symmetry_label"] = AFLOWSymmetry().get_symmetry_label(structure)  
-                case ("SPGLib", _):  
-                    data["symmetry_label"] = SPGLibSymmetry().get_symmetry_label(structure)  
-                case ("moyo", _):  
-                    data["symmetry_label"] = MoyoSymmetry().get_symmetry_label(structure)  
-                case (unknown, _):  
-                    raise ValueError(f"Symmetry algorithm {unknown} not implemented")  
+            match (self.symmetry_labeling, symmetry_label):
+                case (_, label) if label is not None:
+                    data["symmetry_label"] = label
+                case ("AFLOW", _):
+                    data["symmetry_label"] = AFLOWSymmetry().get_symmetry_label(
+                        structure
+                    )
+                case ("SPGLib", _):
+                    data["symmetry_label"] = SPGLibSymmetry().get_symmetry_label(
+                        structure
+                    )
+                case ("moyo", _):
+                    data["symmetry_label"] = MoyoSymmetry().get_symmetry_label(
+                        structure
+                    )
+                case (unknown, _):
+                    raise ValueError(f"Symmetry algorithm {unknown} not implemented")
         if self.include_composition:
             data["composition"] = structure.composition.formula.replace(" ", "")
         return data

--- a/src/material_hasher/similarity/structure_matchers.py
+++ b/src/material_hasher/similarity/structure_matchers.py
@@ -60,7 +60,12 @@ class PymatgenStructureSimilarity(SimilarityMatcherBase):
         float
             Similarity score between the two structures.
         """
-        return self.matcher.get_rms_dist(structure1, structure2)
+        dist = self.matcher.get_rms_dist(structure1, structure2)
+
+        if dist is None:
+            return 0.0
+
+        return 1 - dist[0]
 
     def get_pairwise_equivalence(
         self, structures: list[Structure], threshold: Optional[float] = None


### PR DESCRIPTION
Because the SPGLib-based hasher was found to be pretty reliable, and many people have started using it as default, this PR reverts it to the default symmetry labeler. Updates of LeMat-Bulk will go continue using this to keep the BAWL fingerprint coherent between updates.